### PR TITLE
v1.1.1 - Fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [1.0.1] - update change log
 - Add change log of v1.0.0
+
+## [1.1.1] - fix typo
+- Fix react-ts snippets
+  - "React" to "react"
+- Fix util snippets
+  - "className" to "classNames"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "My Snippets",
   "description": "These are actually my snippets, not just my snippets by name.",
   "icon": "static/img/cat.png",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "publisher": "JaedeokKim",
   "engines": {
     "vscode": "^1.65.0"

--- a/snippets/react-ts.json
+++ b/snippets/react-ts.json
@@ -15,7 +15,7 @@
   "Import FC / Functional Component": {
     "prefix": "ifc",
     "body": [
-      "import { FC } from 'React';",
+      "import { FC } from 'react';",
       "",
       "interface $1Props {",
       "\t$2",
@@ -43,7 +43,7 @@
   "Import FC / Export Functional Component": {
     "prefix": "iefc",
     "body": [
-      "import { FC } from 'React';",
+      "import { FC } from 'react';",
       "",
       "interface $1Props {",
       "\t$2",
@@ -73,7 +73,7 @@
   "Import FC, Functional Component Export Default": {
     "prefix": "ifce",
     "body": [
-      "import { FC } from 'React';",
+      "import { FC } from 'react';",
       "",
       "interface $1Props {",
       "\t$2",

--- a/snippets/util.json
+++ b/snippets/util.json
@@ -7,7 +7,7 @@
   "ClassName Bind": {
     "prefix": "cx",
     "body": [
-      "import className from 'classnames/bind';",
+      "import classNames from 'classnames/bind';",
       "import styles from './$1.module.scss';",
       "",
       "const cx = classNames.bind(styles);"


### PR DESCRIPTION
- 37e8fd2bed1574f762ee9a6c963e60fbc9c4aaef - fixed typo of snippet
`React => react`
`className => classNames`