### PR TITLE
v1.0.2 - Fix typo: React and className

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [1.0.1] - update change log
 - Add change log of v1.0.0
+
+## [1.0.2] - fix typo
+- Fix react-ts snippets
+  - "React" to "react"
+- Fix util snippets
+  - "className" to "classNames"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This means I can add or remove features and modify existing ones as my needs.
 #### ifc - Import FC / Functional Component
 
 ```typescript
-  import { FC } from 'React';
+  import { FC } from 'react';
 
   interface |Props {
     |
@@ -78,7 +78,7 @@ This means I can add or remove features and modify existing ones as my needs.
 #### iefc - Import FC / Export Functional Component
 
 ```typescript
-  import { FC } from 'React';
+  import { FC } from 'react';
 
   interface |Props {
     |
@@ -106,7 +106,7 @@ This means I can add or remove features and modify existing ones as my needs.
 #### ifce - Import FC, Functional Component Export Default
 
 ```typescript
-  import { FC } from 'React';
+  import { FC } from 'react';
 
   interface |Props {
     |
@@ -183,7 +183,7 @@ This means I can add or remove features and modify existing ones as my needs.
 #### cx - ClassName Bind
 
 ```javascript
-  import className from 'classnames/bind';
+  import classNames from 'classnames/bind';
   import styles from './$1.module.scss';
 
   const cx = classNames.bind(styles);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "My Snippets",
   "description": "These are actually my snippets, not just my snippets by name.",
   "icon": "static/img/cat.png",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "JaedeokKim",
   "engines": {
     "vscode": "^1.65.0"

--- a/snippets/react-ts.json
+++ b/snippets/react-ts.json
@@ -15,7 +15,7 @@
   "Import FC / Functional Component": {
     "prefix": "ifc",
     "body": [
-      "import { FC } from 'React';",
+      "import { FC } from 'react';",
       "",
       "interface $1Props {",
       "\t$2",
@@ -43,7 +43,7 @@
   "Import FC / Export Functional Component": {
     "prefix": "iefc",
     "body": [
-      "import { FC } from 'React';",
+      "import { FC } from 'react';",
       "",
       "interface $1Props {",
       "\t$2",
@@ -73,7 +73,7 @@
   "Import FC, Functional Component Export Default": {
     "prefix": "ifce",
     "body": [
-      "import { FC } from 'React';",
+      "import { FC } from 'react';",
       "",
       "interface $1Props {",
       "\t$2",

--- a/snippets/util.json
+++ b/snippets/util.json
@@ -7,7 +7,7 @@
   "ClassName Bind": {
     "prefix": "cx",
     "body": [
-      "import className from 'classnames/bind';",
+      "import classNames from 'classnames/bind';",
       "import styles from './$1.module.scss';",
       "",
       "const cx = classNames.bind(styles);"


### PR DESCRIPTION
- 75e4318b16e41d96ff173be8f227dd916f488456 - fix typo
  - `React => react`
  - `className => classNames`